### PR TITLE
adapt issue text to 'npm run  translate'

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-adapter-to-weblate.md
+++ b/.github/ISSUE_TEMPLATE/add-adapter-to-weblate.md
@@ -10,7 +10,7 @@ assignees:
 **Checklist:**
 
 -   [ ] The adapter contains the i18n files in a separate folder with the default naming scheme
--   [ ] All translation JSON files are up-to-date (call `gulp translateAndUpdateWordsJS` and commit and push those changes to master/main)
+-   [ ] All translation JSON files are up-to-date (call `npm run translate all` or `gulp translateAndUpdateWordsJS` and commit and push those changes to master/main)
 -   [ ] Repository hook is configured on GitHub (set the Payload URL to `https://weblate.iobroker.net/hooks/github/`)
 
 **Request:**


### PR DESCRIPTION
As gulp is no longer the only and preferred mathod for translation, the issue text should suggest to use  'npm run translate all' OR gulp